### PR TITLE
Add thumbnail resizing & fix file location

### DIFF
--- a/includes/import-thumbnail.php
+++ b/includes/import-thumbnail.php
@@ -40,6 +40,10 @@ function fsi_import_thumbnail_file( $thumbnail_file, $post_id = null ) {
 		$thumbnail_file
 	);
 
+	require_once ABSPATH . '/wp-admin/includes/image.php';
+	$attach_data = wp_generate_attachment_metadata( $attachment_id, $thumbnail_file );
+	wp_update_attachment_metadata( $attachment_id, $attach_data );
+
 	if ( $post_id ) {
 		set_post_thumbnail( $post_id, $attachment_id );
 	}

--- a/wp-fast-simple-import.php
+++ b/wp-fast-simple-import.php
@@ -14,8 +14,14 @@ if ( ! defined( 'FSI_IMPORT_PATH' ) ) {
 	define( 'FSI_IMPORT_PATH', WP_CONTENT_DIR . '/import' );
 }
 
+$thumb_path  = FSI_IMPORT_PATH;
+$upload_path = wp_upload_dir();
+if ( false == $upload_path['error'] ) {
+	$thumb_path = $upload_path['basedir'];
+}
+
 if ( ! defined( 'FSI_THUMBNAIL_PATH' ) ) {
-	define( 'FSI_THUMBNAIL_PATH', FSI_IMPORT_PATH );
+	define( 'FSI_THUMBNAIL_PATH', $thumb_path );
 }
 
 foreach ( glob( __DIR__ . '/includes/*.php' ) as $item ) {


### PR DESCRIPTION
- Add calls to generate and save image metadata (generates thumb sizes)
- move import image location to upload dir, because that's what WP expects
