### PR TITLE
Ensure a resolved post isn't from diff. source

### DIFF
--- a/includes/post-resolve.php
+++ b/includes/post-resolve.php
@@ -18,11 +18,11 @@ function fsi_resolve_post( $data ) {
 
 	$query = array_merge( $query, array_intersect_key( $data, $query ) );
 
-	// use _import_id if given
+	// use _import_uid if given
 	if ( isset( $data['_import_uid'] ) && $data['_import_uid'] ) {
-		$id_query               = $query;
-		$id_query['meta_key']   = '_import_uid';
-		$id_query['meta_value'] = $data['_import_uid'];
+		$id_query                = $query;
+		$id_query['meta_key']    = '_import_uid';
+		$id_query['meta_value']  = $data['_import_uid'];
 		$id_query['post_status'] = array(
 			'draft',
 			'publish',
@@ -34,7 +34,7 @@ function fsi_resolve_post( $data ) {
 
 		if ( count( $posts ) > 1 ) {
 			throw new \DomainException(
-				'The following post has duplicates. "_import_id" should exist only once in a post-type: '
+				'The following post has duplicates. "_import_uid" should exist only once in a post-type: '
 				. var_export( $data, true )
 			);
 		}
@@ -53,7 +53,16 @@ function fsi_resolve_post( $data ) {
 		$posts = get_posts( $name_query );
 
 		if ( count( $posts ) == 1 ) {
-			return current( $posts );
+			$post = current( $posts );
+			if ( ! fsi_ensure_resolved_post( $post ) ) {
+				throw new \Exception(
+					'Warning: Post resolved to different/existing UID on post_name match:' . PHP_EOL
+					. var_export( $data, true ) . PHP_EOL
+					. var_export( $post, true ) . PHP_EOL
+				);
+			}
+
+			return $post;
 		}
 	}
 
@@ -68,6 +77,14 @@ function fsi_resolve_post( $data ) {
 
 		foreach ( $posts as $post ) {
 			if ( $post->post_title == $data['post_title'] ) {
+				if ( ! fsi_ensure_resolved_post( $post ) ) {
+					throw new \Exception(
+						'Warning: Post resolved to different/existing UID on title match:' . PHP_EOL
+						. var_export( $data, true ) . PHP_EOL
+						. var_export( $post, true ) . PHP_EOL
+					);
+				}
+
 				return $post;
 			}
 		}
@@ -75,4 +92,18 @@ function fsi_resolve_post( $data ) {
 
 	// give up
 	return false;
+}
+
+/**
+ * Ensure that a resolved post does not belong
+ * to another imported instance
+ *
+ * @var $post   WP_Post
+ * @var $uid    int         (optional) default 0: post MUST NOT have an import_uid
+ *                          If an uid is given, post MUST have this import_uid
+ *
+ * @return      bool        False if import_uid violation found, true otherwise
+ */
+function fsi_ensure_resolved_post( WP_Post $post, $uid = 0 ) {
+	return ( (int) get_post_meta( $post->ID, '_import_uid', true ) == (int) $uid );
 }


### PR DESCRIPTION
@sourcerer-mike Code untested so far, will try tomorrow. Have any thoughts before that?

Commit Message:

When resolving to see if an import is an update instead of new,
we check post_name and post_title.
While we're used to data that makes sense, we shouldn't
assume that a match is always right.

Check the existing post for an import_uid.
If we specify the one we're looking for, it must match.
If we didn't, the post shouldn't have an import_uid (or it should be 0).

Throw some Exceptions if the resolve attempt fails because of this constraint.
